### PR TITLE
Add readme fix ssl certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y libaio1 && rm -rf /var/lib/apt/lists/*
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 RUN gpg --keyserver pgp.mit.edu --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
-RUN apt-get update && apt-get install -y curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://dev.mysql.com/get/Downloads/MySQL-5.1/mysql-5.1.73-linux-x86_64-glibc23.tar.gz" -o mysql.tar.gz \
 	&& apt-get purge -y --auto-remove curl \
 	&& mkdir /usr/local/mysql \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 Docker image for old MySQL 5.1 database, based on [official MySQL image](https://github.com/docker-library/mysql)
+
+Build with:
+
+```
+docker build -t user/mysql51:latest .
+```
+
+Verify with:
+```
+docker images | grep user/mysql51
+```
+
+Run with (data at host:/var/lib/mysql) :
+```
+docker run --name mysql51 -p 3306:3306 -e MYSQL_ROOT_PASSWORD=12345 -v /var/lib/mysql:/var/lib/mysql -d user/mysql51:latest
+```
+
+View log with:
+```
+docker logs mysql51
+```
+
+Command-Line connect to mysql51 on host with:
+
+```
+mysql -h localhost --port=3306 --user=root --password --protocol=tcp 
+# And type password 12345
+```


### PR DESCRIPTION
Removed apt-get install arg that downloaded latest certificate.
* Curl was failing as needed latest certificate installed
* I don't consider this a problem as curl is purged from the image

Also updated the README with useful information.